### PR TITLE
updated alignment_tools.py to Python 3.11+

### DIFF
--- a/helpers/alignment_tools.py
+++ b/helpers/alignment_tools.py
@@ -8,7 +8,11 @@ from functools import reduce
 from dendropy.datamodel.taxonmodel import Taxon
 import time
 import io
-from collections import defaultdict, Mapping
+from collections import defaultdict
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from operator import add
 
 try:
@@ -706,7 +710,7 @@ class MutableAlignment(dict, ReadOnlyAlignment, object):
         If duplicate sequence names are encountered then the old name will
         be replaced.
         """
-        file_obj = open(filename, 'rU')
+        file_obj = open(filename, 'r')
         return self.read_file_object(file_obj, file_format=file_format)
 
     def read_file_object(self, file_obj, file_format='FASTA'):
@@ -1038,7 +1042,7 @@ class ExtendedAlignment(MutableAlignment):
         columns. Labels insertion columns with special labels and labels the
         rest of columns (i.e. original columns) sequentially.
         """
-        handle = open(path, 'rU')
+        handle = open(path, 'r')
         insertions = None
         if aformat.lower() == "stockholm":
             insertions = self._read_sto(handle)


### PR DESCRIPTION
Two small corrections to remove deprecated parts:
- replaced mapping import to collections.abc  (Python 3.10+)
- removed "open U mode" (Python 3.11+)

Now should run with more recent versions of Python (tested locally on Python 3.11.3), hopefully should still run on older Python versions (untested, sorry).